### PR TITLE
Update CI platforms and node build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,19 @@ jobs:
     strategy:
       matrix:
         os:
-          - amazonlinux-2
-          - centos-8
-          - debian-11
-          - fedora-34
-          - oraclelinux-8
-          - ubuntu-2004
-          - ubuntu-2204
+          - amazonlinux-2023
+          - centos-stream-10
+          - debian-12
+          - fedora-40
+          - oraclelinux-9
+          - ubuntu-2404
         workstation_version:
-          - '21.3.346'
-          - '21.11.679'
-        suite: [default]
+          - '24.12.1073'
+          - '25.5.1084'
       fail-fast: false
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Chef
       uses: actionshub/chef-install@main
       with:
@@ -40,7 +38,7 @@ jobs:
     - name: Test-Kitchen
       uses: actionshub/test-kitchen@main
       with:
-        suite: ${{ matrix.suite }}
+        suite: default
         os: ${{ matrix.os }}
       env:
         KITCHEN_LOCAL_YAML: kitchen.dokken.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Chef cookbook for node-build.
 ## Cookbook
 
 ```ruby
-cookbook 'node_build', '~> 1.0.3'
+cookbook 'node_build', '~> 1.0.4'
 ```
 
 ## Resource

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,13 +13,13 @@ berks install --except integration
 ### Lint and Style
 
 ```sh
-CHEF_LICENSE=accept-no-persist delivery local lint
+cookstyle --display-cop-names --extra-details
 ```
 
 ### Unit specs
 
 ```sh
-CHEF_LICENSE=accept-no-persist delivery local unit
+CHEF_LICENSE=accept-no-persist chef exec rspec
 ```
 
 ## Integration tests

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -17,13 +17,17 @@ verifier:
   chef_license: accept-no-persist
 
 platforms:
-  - name: amazonlinux-2
+  - name: amazonlinux-2023
     driver:
-      image: dokken/amazonlinux-2
+      image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
-  - name: centos-8
+  - name: centos-stream-9
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-stream-10
+    driver:
+      image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
   - name: debian-11
     driver:
@@ -31,13 +35,31 @@ platforms:
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -qq
-  - name: fedora-34
+  - name: debian-12
     driver:
-      image: dokken/fedora-34
+      image: dokken/debian-12
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -qq
+  - name: fedora-40
+    driver:
+      image: dokken/fedora-40
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: fedora-41
+    driver:
+      image: dokken/fedora-41
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: fedora-42
+    driver:
+      image: dokken/fedora-42
       pid_one_command: /usr/lib/systemd/systemd
   - name: oraclelinux-8
     driver:
       image: dokken/oraclelinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: oraclelinux-9
+    driver:
+      image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
   - name: ubuntu-20.04
     driver:
@@ -48,6 +70,12 @@ platforms:
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -qq
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -qq

--- a/libraries/chef/node_build.rb
+++ b/libraries/chef/node_build.rb
@@ -6,8 +6,10 @@ class Chef
 
     def python
       version = node['platform_version'].to_i
-      if platform?('oracle') && version == 8 then 'python36'
-      elsif platform?(*supported_plaftorms) then 'python3'
+      if platform?('debian', 'ubuntu') then 'python3'
+      elsif platform?('oracle') && version == 8 then 'python36'
+      elsif platform?('oracle') && version == 9 then 'python3'
+      elsif platform?(*supported_platforms) then 'python'
       end
     end
 
@@ -19,14 +21,14 @@ class Chef
     end
 
     def make
-      'make' if platform?(*supported_plaftorms)
+      'make' if platform?(*supported_platforms)
     end
 
     def tar
       'tar' if platform?('amazon')
     end
 
-    def supported_plaftorms
+    def supported_platforms
       %w(amazon centos debian fedora oracle ubuntu)
     end
   end

--- a/libraries/chef/node_build.rb
+++ b/libraries/chef/node_build.rb
@@ -1,15 +1,13 @@
 class Chef
   module NodeBuild
     def node_build_dependencies
-      [python, gcc, make].compact
+      [tar, python, gcc, make].compact
     end
 
     def python
       version = node['platform_version'].to_i
-      if platform?('centos') && version >= 8 then 'python3'
-      elsif platform?('oracle') && version >= 8 then 'python36'
-      elsif platform?('ubuntu') && version >= 20 then 'python3'
-      elsif platform?(*supported_plaftorms) then 'python'
+      if platform?('oracle') && version == 8 then 'python36'
+      elsif platform?(*supported_plaftorms) then 'python3'
       end
     end
 
@@ -22,6 +20,10 @@ class Chef
 
     def make
       'make' if platform?(*supported_plaftorms)
+    end
+
+    def tar
+      'tar' if platform?('amazon')
     end
 
     def supported_plaftorms

--- a/test/integration/default/standalone_install_spec.rb
+++ b/test/integration/default/standalone_install_spec.rb
@@ -29,7 +29,7 @@ end
 
 control 'build a node version with a node-build binary' do
   node_versions_home = '/tmp/node-build-versions'
-  node_version = '12.16.1'
+  node_version = '24.3.0'
 
   node_home = ::File.join node_versions_home, node_version
   describe command("#{node_build_bin} #{node_version} #{node_home}") do


### PR DESCRIPTION
Updated CI and Test Kitchen configurations to use newer OS versions (e.g., amazonlinux-2023, centos-stream-10, debian-12, fedora-40, oraclelinux-9, ubuntu-24.04). Added 'tar' as a dependency for Amazon in node_build.rb and updated Python version logic. Changed test node version in standalone_install_spec.rb to 24.3.0.